### PR TITLE
Add searchquerys

### DIFF
--- a/src/controllers/redditController.js
+++ b/src/controllers/redditController.js
@@ -6,8 +6,8 @@ exports.syncReddits = async (req, res) => {
 };
 
 exports.listReddits = async (req, res) => {
-  const { page = 1, limit = 10 } = req.query;
-  const result = await redditService.getPaginatedReddits(Number(page), Number(limit));
+  const { page = 1, limit = 10, q } = req.query;
+  const result = await redditService.getPaginatedReddits(Number(page), Number(limit), q);
   res.json(result);
 };
 

--- a/src/routes/redditRoutes.js
+++ b/src/routes/redditRoutes.js
@@ -29,6 +29,10 @@ router.post('/sync', authMiddleware, redditController.syncReddits);
  *       - in: query
  *         name: limit
  *         schema: { type: integer, default: 10 }
+ *       - in: query
+ *         name: q
+ *         schema: { type: string }
+ *         description: Búsqueda parcial en name, title o description
  *     responses:
  *       200:
  *         description: Resultado paginado

--- a/src/services/redditService.js
+++ b/src/services/redditService.js
@@ -12,10 +12,20 @@ const fetchAndStoreReddits = async () => {
   await Reddit.bulkCreate(subreddits, { ignoreDuplicates: true });
 };
 
-const getPaginatedReddits = async (page = 1, limit = 10) => {
+const getPaginatedReddits = async (page = 1, limit = 10, q) => {
+  const where = {};
+  if (q) {
+    where[Op.or] = [
+      { name: { [Op.iLike]: `%${q}%` } },
+      { title: { [Op.iLike]: `%${q}%` } },
+      { description: { [Op.iLike]: `%${q}%` } },
+    ];
+  }
   return Reddit.findAndCountAll({
+    where,
     offset: (page - 1) * limit,
     limit,
+    order: [['name', 'ASC']],
   });
 };
 

--- a/src/services/redditService.js
+++ b/src/services/redditService.js
@@ -1,5 +1,6 @@
 const axios = require('axios');
 const Reddit = require('../models/Reddit');
+const { Op } = require('sequelize')
 
 const fetchAndStoreReddits = async () => {
   const { data } = await axios.get('https://www.reddit.com/reddits.json');


### PR DESCRIPTION
This pull request adds support for partial text search to the paginated Reddit listing API endpoint. Now, users can filter subreddits by a search term that matches the `name`, `title`, or `description` fields. The implementation uses Sequelize's `iLike` operator for case-insensitive matching and updates both the backend service and API documentation.

**Feature: Search functionality for paginated Reddit listing**

* Added a `q` query parameter to the `listReddits` controller method in `redditController.js`, passing it to the service layer for filtering.
* Updated the `getPaginatedReddits` function in `redditService.js` to accept a `q` parameter and filter results using Sequelize's `Op.iLike` on `name`, `title`, and `description`. Results are now ordered by `name` ascending.
* Imported Sequelize's `Op` operator in `redditService.js` for advanced query capabilities.

**Documentation: API parameter update**

* Documented the new `q` query parameter in the OpenAPI comments for the `/sync` endpoint in `redditRoutes.js`, describing its usage for partial search.